### PR TITLE
Update imports to be compatible with the latest version of ddtrace

### DIFF
--- a/ddtrace_graphql/__init__.py
+++ b/ddtrace_graphql/__init__.py
@@ -16,7 +16,7 @@ only certain calls you can use the ``traced_graphql`` function::
 """
 
 
-from ddtrace.contrib.util import require_modules
+from ddtrace.contrib import require_modules
 
 required_modules = ['graphql']
 

--- a/ddtrace_graphql/base.py
+++ b/ddtrace_graphql/base.py
@@ -3,7 +3,7 @@ import os
 
 import ddtrace
 import graphql
-from ddtrace.ext import errors as ddtrace_errors
+from ddtrace.constants import ERROR_MSG, ERROR_STACK, ERROR_TYPE
 
 from ddtrace_graphql import utils
 
@@ -79,13 +79,13 @@ def traced_graphql_wrapped(
                         ERRORS,
                         utils.format_errors(result.errors))
                     span.set_tag(
-                        ddtrace_errors.ERROR_STACK,
+                        ERROR_STACK,
                         utils.format_errors_traceback(result.errors))
                     span.set_tag(
-                        ddtrace_errors.ERROR_MSG,
+                        ERROR_MSG,
                         utils.format_errors_msg(result.errors))
                     span.set_tag(
-                        ddtrace_errors.ERROR_TYPE,
+                        ERROR_TYPE,
                         utils.format_errors_type(result.errors))
 
                     span.error = int(utils.is_server_error(

--- a/ddtrace_graphql/patch.py
+++ b/ddtrace_graphql/patch.py
@@ -8,9 +8,8 @@ import logging
 import os
 
 import graphql
-import graphql.backend.core
 import wrapt
-from ddtrace.util import unwrap
+from ddtrace.internal.utils.wrappers import unwrap
 
 from ddtrace_graphql.base import traced_graphql_wrapped
 


### PR DESCRIPTION
This lib is not maintained anymore so we've forked it and made the minor edits needed to get it working with the latest version of ddtrace. Whether or not we keep this remains to be seen.